### PR TITLE
Add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo"
+    "test": "xo && ava"
   },
   "files": [
     "index.js",
@@ -48,6 +48,14 @@
     "semver": "^5.3.0"
   },
   "devDependencies": {
+    "@polka/send-type": "^0.4.0",
+    "ava": "^0.25.0",
+    "get-port": "^3.2.0",
+    "polka": "^0.4.0",
+    "tempy": "^0.2.1",
+    "unique-string": "^1.0.0",
+    "write-ini-file": "^1.0.0",
+    "write-pkg": "^3.2.0",
     "xo": "*"
   }
 }

--- a/test/helpers/create-server.js
+++ b/test/helpers/create-server.js
@@ -1,0 +1,30 @@
+import {parse as parseUrl} from 'url';
+import polka from 'polka';
+import send from '@polka/send-type';
+import getPort from 'get-port';
+
+export default async () => {
+	const port = await getPort();
+
+	await polka()
+		.get('*', (req, res) => {
+			const url = parseUrl(req.url);
+			const packageName = url.pathname;
+
+			return send(res, 200, {
+				packageName,
+				'dist-tags': {
+					latest: '2.0.0'
+				},
+				versions: {
+					'2.0.0': {
+						packageName,
+						version: '2.0.0'
+					}
+				}
+			});
+		})
+		.listen(port);
+
+	return `http://localhost:${port}`;
+};

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -1,0 +1,5 @@
+import execa from 'execa';
+
+export default directory => {
+	return execa(`${__dirname}/../../check.js`, {cwd: directory});
+};

--- a/test/helpers/get-subtext.js
+++ b/test/helpers/get-subtext.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import pify from 'pify';
+import plist from 'plist';
+
+const fsP = pify(fs);
+
+export default async directory => {
+	const infoPlist = plist.parse(await fsP.readFile(`${directory}/info.plist`, 'utf8'));
+	return infoPlist.objects[0].config.subtext;
+};

--- a/test/helpers/set-registry.js
+++ b/test/helpers/set-registry.js
@@ -1,0 +1,5 @@
+import writeIniFile from 'write-ini-file';
+
+export default (directory, registry) => {
+	return writeIniFile(`${directory}/.npmrc`, {registry});
+};

--- a/test/helpers/write-info-plist.js
+++ b/test/helpers/write-info-plist.js
@@ -1,0 +1,18 @@
+import fs from 'fs';
+
+import pify from 'pify';
+import plist from 'plist';
+
+const fsP = pify(fs);
+
+const contents = {
+	objects: [{
+		config: {
+			subtext: ''
+		}
+	}]
+};
+
+export default directory => {
+	return fsP.writeFile(`${directory}/info.plist`, plist.build(contents));
+};

--- a/test/helpers/write-package-json.js
+++ b/test/helpers/write-package-json.js
@@ -1,0 +1,5 @@
+import writePkg from 'write-pkg';
+
+export default (directory, name, version) => {
+	return writePkg(directory, {name, version});
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,45 @@
+import test from 'ava';
+import CacheConf from 'cache-conf';
+import tempy from 'tempy';
+import uniqueString from 'unique-string';
+
+import createServer from './helpers/create-server';
+import exec from './helpers/exec';
+import getSubtext from './helpers/get-subtext';
+import setRegistry from './helpers/set-registry';
+import writeInfoPlist from './helpers/write-info-plist';
+import writePackageJson from './helpers/write-package-json';
+
+test.beforeEach(async t => {
+	const directory = tempy.directory();
+	const packageName = uniqueString();
+	const registryUrl = await createServer();
+
+	await setRegistry(directory, registryUrl);
+	await writeInfoPlist(directory);
+
+	t.context = {directory, packageName};
+});
+
+test.afterEach.always(t => {
+	const config = new CacheConf({projectName: 'alfred-notifier'});
+	config.delete(t.context.packageName);
+});
+
+test('notifies if an update is available', async t => {
+	const {directory, packageName} = t.context;
+
+	await writePackageJson(directory, packageName, '1.0.0');
+	await exec(directory);
+
+	t.is(await getSubtext(directory), `Update available: 1.0.0 → 2.0.0. Run \`npm install -g ${packageName}\``);
+});
+
+test('does nothing if up to date', async t => {
+	const {directory, packageName} = t.context;
+
+	await writePackageJson(directory, packageName, '2.0.0');
+	await exec(directory);
+
+	t.is(await getSubtext(directory), '');
+});


### PR DESCRIPTION
Adds tests for if an update is available and if the workflow is already up to date. Closes #1.

For each test, a temporary directory is created with a `package.json` and an `info.plist`. A fake registry server is set up (and configured via `.npmrc`) which always returns v2.0.0 as the latest version. The first test calls `check.js` with v1.0.0 and expects the `subtext` in `info.plist` to be updated. The second test runs with v2.0.0 and expects the `subtext` to remain the same.

<details open>
<summary>Why use a random package name?</summary>

alfred-notifier caches the registry’s response using [cache-conf](https://github.com/SamVerschueren/cache-conf). Using random package names allows the tests to run in parallel without interfering with the cache.
</details>