### PR TITLE
Fix opening of multiple Alfred instances

### DIFF
--- a/check.js
+++ b/check.js
@@ -33,7 +33,7 @@ readPkg(workflowPath)
 			if (!semver.eq(res.latest, res.current)) {
 				// Overwrite `info.plist` and reload the workflows
 				return notify(workflowPath, `Update available: ${res.current} → ${res.latest}. Run \`npm install -g ${res.name}\``)
-					.then(() => execa('open', ['-n', '-a', 'Alfred 3']));
+					.then(() => execa('open', ['-a', 'Alfred 3']));
 			}
 		});
 	});


### PR DESCRIPTION
Fixes #8 by removing the `-n` option from the `open` command. From `man open`:

> **-n**  Open a new instance of the application(s) even if one is already running.